### PR TITLE
fixed language type in readme usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ## Usage
 
-```json
+```js
  const  flatTree = require('flat-json');
 
  const data = [


### PR DESCRIPTION
In my previous PR, by mistake I added `json` in README.md, it was supposed to be `js`.
This pull request will fix that.